### PR TITLE
add filters from kafka and redis

### DIFF
--- a/blocks/kafka/sources.py
+++ b/blocks/kafka/sources.py
@@ -172,12 +172,13 @@ def _make_events(
     events: List[Event] = []
     for msg in messages:
         event = cast(msg, topic.event, ignore_errors=ignore_errors, verbose_log_errors=topic.verbose_log_errors)
-        if event is not None:
-            if topic.commit_manually:
-                # Do not know in advance which event should be committed.
-                # So stashing necessary meta to every event from topics which may be committed manually.
-                _stash_msg_meta(event, msg)
-            events.append(event)
+        if topic.filter_function(event):
+            if event is not None:
+                if topic.commit_manually:
+                    # Do not know in advance which event should be committed.
+                    # So stashing necessary meta to every event from topics which may be committed manually.
+                    _stash_msg_meta(event, msg)
+                events.append(event)
 
     if topic.batched:
         if topic.batch_event is None:

--- a/blocks/kafka/topics.py
+++ b/blocks/kafka/topics.py
@@ -2,7 +2,7 @@
 
 import datetime
 from enum import Enum
-from typing import Type, Optional
+from typing import Type, Optional, Callable, Dict
 
 from wunderkafka import AnyConsumer, AnyProducer, ConsumerConfig, ProducerConfig
 
@@ -136,6 +136,7 @@ class InputTopic(_Topic):
         name: str,
         event: Type[Event],
         *,
+        filter_function: Callable[[Event], bool] = lambda x: True,
         group_id: Optional[str] = None,
         key: Optional[Type[Event]] = None,
         commit_offset: str = 'never',
@@ -160,6 +161,7 @@ class InputTopic(_Topic):
 
         :param name:            Kafka topic name to be consumed.
         :param event:           Event-inherited model for message values to be unpacked to.
+        :param filter_function: The function of filtering messages from the topic.
         :param group_id:        Override consumer's group id from config.
         :param key:             Event-inherited model for messages keys to be unpacked to, if any.
         :param commit_offset:   One of possible strategies of how to commit offsets for a given event.
@@ -207,6 +209,7 @@ class InputTopic(_Topic):
         self.poll_timeout = poll_timeout
         self.messages_limit = messages_limit
         self.consumer = consumer
+        self.filter_function = filter_function
 
     # Shortening code in Consumers, but still exhibiting strings in API.
     @property

--- a/blocks/redis/processors.py
+++ b/blocks/redis/processors.py
@@ -13,7 +13,7 @@ class RedisProducer(Processor):
     Class represents event processor that writes messages to Redis streams
     based on data received from event. On initialization must get list
     of output streams in order to perform arbitrary mapping. In most cases
-    you don't need to use RedisProducer directly, RedisApp can make this for you.
+    you don't need to use RedisProducer directly, RedisStreamsApp can make this for you.
 
     Example::
 

--- a/blocks/redis/streams.py
+++ b/blocks/redis/streams.py
@@ -1,5 +1,5 @@
 import time
-from typing import Type
+from typing import Type, Callable, Dict, Any, Optional
 
 from blocks import Event
 
@@ -19,12 +19,23 @@ class InputStream(_Stream):
         name: str,
         event: Type[Event],
         *,
+        filter_function: Callable[[Event], bool] = lambda x: True,
         start_id: str = f'{int(time.time() * 1000)}-0',
         messages_limit: int = 1000,
     ) -> None:
+        """
+        Added the ability to filter events from the topic. Example:
+
+        def filter_func(value: Any) -> bool:
+            return ...
+
+        streams = [InputStream(name='test', event=SignalP, filter_function=filter_func)]
+        """
         super().__init__(name, event)
         self.messages_limit = messages_limit
         self.start_id = start_id
+        self.filter_function = filter_function
+
 
 
 class OutputStream(_Stream):


### PR DESCRIPTION
Added possibility to set filters for kafka and radis, filters are set by external function, which is passed to InputTopic and InputStream respectively. I think that there is no point in writing filters in the database, as everything can be set there via select, a filter on an already ready query will only confuse everything and may lead to unpredictable results.
And I decided to translate the message into a event first, it is more usable, as the user does not bother with validation and deserialization and immediately works with the filter. If everything is ok, the event goes on, if the filter gives False, the event is ignored